### PR TITLE
Make timestamp configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,7 @@ $filesystem = new Filesystem(new MemoryAdapter());
 $filesystem->write('new_file.txt', 'yay a new text file!');
 
 $contents = $filesystem->read('new_file.txt');
+
+// Explicitly set timestamp (e.g. for testing)
+$filesystem->write('old_file.txt', 'very old content', ['timestamp' => 13377331]);
 ```

--- a/src/MemoryAdapter.php
+++ b/src/MemoryAdapter.php
@@ -227,7 +227,7 @@ class MemoryAdapter implements AdapterInterface
         }
 
         $this->storage[$path]['contents'] = $contents;
-        $this->storage[$path]['timestamp'] = time();
+        $this->storage[$path]['timestamp'] = $config->get('timestamp', time());
         $this->storage[$path]['size'] = Util::contentSize($contents);
 
         if ($visibility = $config->get('visibility')) {

--- a/tests/MemoryAdapterTest.php
+++ b/tests/MemoryAdapterTest.php
@@ -245,4 +245,13 @@ class MemoryAdapterTest  extends \PHPUnit_Framework_TestCase
         $this->assertSame('new contents', $result['contents']);
         $this->assertFalse($this->adapter->write('file.txt/new_file.txt', 'contents', new Config()));
     }
+
+    public function testTimestampCanBeConfigured() {
+        $now = 1460000000;
+        $this->adapter->write('file.txt', 'content', new Config(['timestamp' => $now]));
+        $this->assertEquals($now, $this->adapter->getTimestamp('file.txt')['timestamp']);
+        $earlier = 1300000000;
+        $this->adapter->update('file.txt', 'new contents', new Config(['timestamp' => $earlier]));
+        $this->assertEquals($earlier, $this->adapter->getTimestamp('file.txt')['timestamp']);
+    }
 }


### PR DESCRIPTION
Added code to optionally set the timestamp in the configuration. This
allows using the memory adapter in testing environments for testing
time-based behaviors.
