### PR TITLE
Make timestamp configurable

### DIFF
--- a/InMemoryFile.php
+++ b/InMemoryFile.php
@@ -27,10 +27,10 @@ class InMemoryFile
      */
     private $visibility;
 
-    public function updateContents(string $contents): void
+    public function updateContents(string $contents, ?int $timestamp): void
     {
         $this->contents = $contents;
-        $this->lastModified = time();
+        $this->lastModified = $timestamp ?: time();
     }
 
     public function lastModified(): int
@@ -74,5 +74,13 @@ class InMemoryFile
     public function visibility(): ?string
     {
         return $this->visibility;
+    }
+
+    public function withLastModified(int $lastModified): self
+    {
+        $clone = clone $this;
+        $clone->lastModified = $lastModified;
+
+        return $clone;
     }
 }

--- a/InMemoryFilesystemAdapter.php
+++ b/InMemoryFilesystemAdapter.php
@@ -51,7 +51,7 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
     {
         $path = $this->preparePath($path);
         $file = $this->files[$path] = $this->files[$path] ?? new InMemoryFile();
-        $file->updateContents($contents);
+        $file->updateContents($contents, $config->get('timestamp'));
 
         $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
         $file->setVisibility($visibility);
@@ -231,7 +231,9 @@ class InMemoryFilesystemAdapter implements FilesystemAdapter
             throw UnableToCopyFile::fromLocationTo($source, $destination);
         }
 
-        $this->files[$destination] = clone $this->files[$source];
+        $lastModified = $config->get('timestamp', time());
+
+        $this->files[$destination] = $this->files[$source]->withLastModified($lastModified);
     }
 
     private function preparePath(string $path): string

--- a/InMemoryFilesystemAdapterTest.php
+++ b/InMemoryFilesystemAdapterTest.php
@@ -273,6 +273,22 @@ class InMemoryFilesystemAdapterTest extends FilesystemAdapterTestCase
         parent::fetching_unknown_mime_type_of_a_file();
     }
 
+    /**
+     * @test
+     */
+    public function using_custom_timestamp(): void
+    {
+        $adapter = $this->adapter();
+
+        $now = 100;
+        $adapter->write('file.txt', 'contents', new Config(['timestamp' => $now]));
+        $this->assertEquals($now, $adapter->lastModified('file.txt')->lastModified());
+
+        $earlier = 50;
+        $adapter->copy('file.txt', 'new_file.txt', new Config(['timestamp' => $earlier]));
+        $this->assertEquals($earlier, $adapter->lastModified('new_file.txt')->lastModified());
+    }
+
     protected static function createFilesystemAdapter(): FilesystemAdapter
     {
         return new InMemoryFilesystemAdapter();


### PR DESCRIPTION
Use an optional `timestamp` option in the config to set the `lastModified` attribute when writing or copying a file.
This allows using the memory adapter in testing environments for testing time-based behaviors.

I tried to write a test but I didn't find how to run them.